### PR TITLE
Update Dockerfile to slim Python versions

### DIFF
--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -1,5 +1,5 @@
 # https://fastapi.tiangolo.com/deployment/docker/#build-a-docker-image-with-a-single-file-fastapi
-FROM python:3.9
+FROM python:3.9-slim
 
 WORKDIR /code
 

--- a/Dockerfile.simple.pdm
+++ b/Dockerfile.simple.pdm
@@ -2,7 +2,7 @@
 # https://fastapi.tiangolo.com/deployment/docker/#build-a-docker-image-with-a-single-file-fastapi
 
 # build stage
-FROM python:3.9 AS builder
+FROM python:3.9-slim AS builder
 
 # install PDM
 RUN pip install -U pip setuptools wheel


### PR DESCRIPTION
Use the `-slim` version of Python so Dockerfile build is smaller:

## Compare _full_ vs _slim_ versions

| Python Image Version | Dockerfile `FROM python` | Size |
|:---|:---|:--:|
| **_Full_** | `FROM python:3.9` | 219MB |
| **_Slim_** | `FROM python:3.9-slim` | 1.01GB |

```
$ docker image ls
REPOSITORY      TAG       IMAGE ID       CREATED         SIZE
docker-slim     latest    1518e9ae1f13   4 minutes ago   219MB
docker-full     latest    9c2a8cb83da4   5 hours ago     1.01GB
```
